### PR TITLE
修复8.0+悬浮窗权限

### DIFF
--- a/app/src/main/java/com/example/gsyvideoplayer/WindowActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/WindowActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.support.annotation.RequiresApi;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
@@ -56,8 +57,7 @@ public class WindowActivity extends AppCompatActivity {
 
     @RequiresApi(api = 23)
     private void requestAlertWindowPermission() {
-        Intent intent = new Intent("android.settings.action.MANAGE_OVERLAY_PERMISSION");
-        intent.setData(Uri.parse("package:" + getPackageName()));
+        Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.parse("package:" + getPackageName()));
         startActivityForResult(intent, 1);
     }
 

--- a/app/src/main/java/com/example/gsyvideoplayer/utils/floatUtil/FloatPhone.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/utils/floatUtil/FloatPhone.java
@@ -2,6 +2,7 @@ package com.example.gsyvideoplayer.utils.floatUtil;
 
 import android.content.Context;
 import android.graphics.PixelFormat;
+import android.os.Build;
 import android.view.View;
 import android.view.WindowManager;
 
@@ -33,9 +34,15 @@ class FloatPhone extends FloatView {
 
     @Override
     public void setView(View view) {
+        int layout_type;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            layout_type = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
+        } else {
+            layout_type = WindowManager.LayoutParams.TYPE_PHONE;
+        }
         mLayoutParams.flags = WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
                 | WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE;
-        mLayoutParams.type = WindowManager.LayoutParams.TYPE_PHONE;
+        mLayoutParams.type = layout_type;
         mLayoutParams.windowAnimations = 0;
         mView = view;
     }

--- a/app/src/main/java/com/example/gsyvideoplayer/utils/floatUtil/Util.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/utils/floatUtil/Util.java
@@ -2,7 +2,9 @@ package com.example.gsyvideoplayer.utils.floatUtil;
 
 import android.content.Context;
 import android.graphics.Point;
+import android.os.Build;
 import android.provider.Settings;
+import android.support.annotation.RequiresApi;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
@@ -22,16 +24,9 @@ public class Util {
         return inflate.inflate(layoutId, null);
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.M)
     public static boolean hasPermission(Context context) {
-        Boolean result;
-        try {
-            Class clazz = Settings.class;
-            Method canDrawOverlays = clazz.getDeclaredMethod("canDrawOverlays", Context.class);
-            result = (Boolean) canDrawOverlays.invoke(null, context);
-        } catch (Exception e) {
-            result = false;
-        }
-        return result;
+        return Settings.canDrawOverlays(context);
     }
 
 


### PR DESCRIPTION
悬浮窗口在Android 8.0+崩溃，提示没有权限（实际已获得权限）

问题代码：
``` java
class FloatPhone

@Override
public void setView(View view) {
    mLayoutParams.flags = WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
            | WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE;
    mLayoutParams.type = WindowManager.LayoutParams.TYPE_PHONE;
    mLayoutParams.windowAnimations = 0;
    mView = view;
}
```
mLayoutParams.type在8.0以上设备上需要改为`WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY`
具体参考这个回答[https://stackoverflow.com/a/47103959](https://stackoverflow.com/a/47103959)

同时权限检查建议使用系统方法
```java
Settings.canDrawOverlays(context)
```
在有些6.0以下机型上，也控制了悬浮窗权限，这种情况未进行处理