### PR TITLE
修复GSYVideoHelper切换全屏导致定时任务停止的问题

### DIFF
--- a/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/utils/GSYVideoHelper.java
+++ b/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/utils/GSYVideoHelper.java
@@ -247,6 +247,7 @@ public class GSYVideoHelper {
                 mGsyVideoPlayer.getFullscreenButton().setImageResource(mGsyVideoPlayer.getEnlargeImageRes());
                 mGsyVideoPlayer.getBackButton().setVisibility(View.GONE);
                 mGsyVideoPlayer.setIfCurrentIsFullscreen(false);
+                mGsyVideoPlayer.restartTimerTask();
                 if (mVideoOptionBuilder.getVideoAllCallBack() != null) {
                     Debuger.printfLog("onQuitFullscreen");
                     mVideoOptionBuilder.getVideoAllCallBack().onQuitFullscreen(mVideoOptionBuilder.getUrl(), mVideoOptionBuilder.getVideoTitle(), mGsyVideoPlayer);
@@ -318,6 +319,7 @@ public class GSYVideoHelper {
             }
         }
         mGsyVideoPlayer.setIfCurrentIsFullscreen(true);
+        mGsyVideoPlayer.restartTimerTask();
         if (mVideoOptionBuilder.getVideoAllCallBack() != null) {
             Debuger.printfLog("onEnterFullscreen");
             mVideoOptionBuilder.getVideoAllCallBack().onEnterFullscreen(mVideoOptionBuilder.getUrl(), mVideoOptionBuilder.getVideoTitle(), mGsyVideoPlayer);

--- a/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/StandardGSYVideoPlayer.java
+++ b/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/StandardGSYVideoPlayer.java
@@ -864,5 +864,13 @@ public class StandardGSYVideoPlayer extends GSYVideoPlayer {
         }
     }
 
-
+    /**
+     * 重新开启进度查询以及控制view消失的定时任务
+     * 用于解决GSYVideoHelper中通过removeview方式做全屏切换导致的定时任务停止的问题
+     * GSYVideoControlView   onDetachedFromWindow（）
+     */
+    public void restartTimerTask() {
+        startProgressTimer();
+        startDismissControlViewTimer();
+    }
 }


### PR DESCRIPTION
将GSYVideoHelper中通过removeview方式做全屏切换而触发GSYVideoControlView中的onDetachedFromWindow方法，导致关闭的定时任务重新开启