### PR TITLE
rename wiget to widget

### DIFF
--- a/app/src/main/java/com/example/gsyvideoplayer/DanmkuVideoActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/DanmkuVideoActivity.java
@@ -78,7 +78,7 @@ public class DanmkuVideoActivity extends AppCompatActivity {
         //初始化不打开外部的旋转
         orientationUtils.setEnable(false);
 
-        danmakuVideoPlayer.setIsTouchWiget(true);
+        danmakuVideoPlayer.setIsTouchWidget(true);
         //关闭自动旋转
         danmakuVideoPlayer.setRotateViewAuto(false);
         danmakuVideoPlayer.setLockLand(false);

--- a/app/src/main/java/com/example/gsyvideoplayer/DetailADPlayer.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/DetailADPlayer.java
@@ -63,7 +63,7 @@ public class DetailADPlayer extends GSYBaseActivityDetail<ListGSYVideoPlayer> {
 
         resolveNormalVideoUI();
 
-        detailPlayer.setIsTouchWiget(true);
+        detailPlayer.setIsTouchWidget(true);
         //关闭自动旋转
         detailPlayer.setRotateViewAuto(false);
         detailPlayer.setLockLand(false);

--- a/app/src/main/java/com/example/gsyvideoplayer/DetailADPlayer2.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/DetailADPlayer2.java
@@ -136,7 +136,7 @@ public class DetailADPlayer2 extends GSYBaseADActivityDetail<NormalGSYVideoPlaye
                 .setVideoTitle(" ")
                 .setFullHideActionBar(true)
                 .setFullHideStatusBar(true)
-                .setIsTouchWiget(true)
+                .setIsTouchWidget(true)
                 .setRotateViewAuto(false)
                 .setLockLand(false)
                 .setShowFullAnimation(false)//打开动画

--- a/app/src/main/java/com/example/gsyvideoplayer/DetailControlActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/DetailControlActivity.java
@@ -180,7 +180,7 @@ public class DetailControlActivity extends GSYBaseActivityDetail<StandardGSYVide
                 .setUrl(url)
                 .setCacheWithPlay(true)
                 .setVideoTitle(" ")
-                .setIsTouchWiget(true)
+                .setIsTouchWidget(true)
                 .setRotateViewAuto(false)
                 .setLockLand(false)
                 .setShowFullAnimation(true)//打开动画

--- a/app/src/main/java/com/example/gsyvideoplayer/DetailFilterActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/DetailFilterActivity.java
@@ -273,7 +273,7 @@ public class DetailFilterActivity extends GSYBaseActivityDetail<StandardGSYVideo
                 .setUrl(url)
                 .setCacheWithPlay(true)
                 .setVideoTitle(" ")
-                .setIsTouchWiget(true)
+                .setIsTouchWidget(true)
                 .setRotateViewAuto(false)
                 .setLockLand(false)
                 .setShowFullAnimation(false)

--- a/app/src/main/java/com/example/gsyvideoplayer/DetailListPlayer.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/DetailListPlayer.java
@@ -62,7 +62,7 @@ public class DetailListPlayer extends GSYBaseActivityDetail<ListGSYVideoPlayer> 
 
         resolveNormalVideoUI();
 
-        detailPlayer.setIsTouchWiget(true);
+        detailPlayer.setIsTouchWidget(true);
         //关闭自动旋转
         detailPlayer.setRotateViewAuto(false);
         detailPlayer.setLockLand(false);

--- a/app/src/main/java/com/example/gsyvideoplayer/DetailMoreTypeActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/DetailMoreTypeActivity.java
@@ -87,8 +87,8 @@ public class DetailMoreTypeActivity extends AppCompatActivity {
         //初始化不打开外部的旋转
         orientationUtils.setEnable(false);
 
-        detailPlayer.setIsTouchWiget(true);
-        //detailPlayer.setIsTouchWigetFull(false);
+        detailPlayer.setIsTouchWidget(true);
+        //detailPlayer.setIsTouchWidgetFull(false);
         //关闭自动旋转
         detailPlayer.setRotateViewAuto(false);
         detailPlayer.setLockLand(false);

--- a/app/src/main/java/com/example/gsyvideoplayer/DetailPlayer.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/DetailPlayer.java
@@ -86,7 +86,7 @@ public class DetailPlayer extends AppCompatActivity {
         header.put("ee", "33");
         GSYVideoOptionBuilder gsyVideoOption = new GSYVideoOptionBuilder();
         gsyVideoOption.setThumbImageView(imageView)
-                .setIsTouchWiget(true)
+                .setIsTouchWidget(true)
                 .setRotateViewAuto(false)
                 .setLockLand(false)
                 .setAutoFullWithSize(true)

--- a/app/src/main/java/com/example/gsyvideoplayer/InputUrlDetailActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/InputUrlDetailActivity.java
@@ -71,7 +71,7 @@ public class InputUrlDetailActivity extends AppCompatActivity {
 
         gsyVideoOptionBuilder = new GSYVideoOptionBuilder()
                 .setThumbImageView(imageView)
-                .setIsTouchWiget(true)
+                .setIsTouchWidget(true)
                 .setRotateViewAuto(false)
                 .setLockLand(false)
                 .setShowFullAnimation(false)

--- a/app/src/main/java/com/example/gsyvideoplayer/ListADVideoActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/ListADVideoActivity.java
@@ -210,8 +210,8 @@ public class ListADVideoActivity extends AppCompatActivity {
             holder.adVideoPlayer.setReleaseWhenLossAudio(false);
             holder.gsyVideoPlayer.setShowFullAnimation(false);
             holder.adVideoPlayer.setShowFullAnimation(false);
-            holder.gsyVideoPlayer.setIsTouchWiget(false);
-            holder.adVideoPlayer.setIsTouchWiget(false);
+            holder.gsyVideoPlayer.setIsTouchWidget(false);
+            holder.adVideoPlayer.setIsTouchWidget(false);
 
             holder.gsyVideoPlayer.setNeedLockFull(true);
 

--- a/app/src/main/java/com/example/gsyvideoplayer/ListADVideoActivity2.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/ListADVideoActivity2.java
@@ -211,8 +211,8 @@ public class ListADVideoActivity2 extends AppCompatActivity {
             holder.adVideoPlayer.setReleaseWhenLossAudio(false);
             holder.gsyVideoPlayer.setShowFullAnimation(false);
             holder.adVideoPlayer.setShowFullAnimation(false);
-            holder.gsyVideoPlayer.setIsTouchWiget(false);
-            holder.adVideoPlayer.setIsTouchWiget(false);
+            holder.gsyVideoPlayer.setIsTouchWidget(false);
+            holder.adVideoPlayer.setIsTouchWidget(false);
 
             holder.gsyVideoPlayer.setNeedLockFull(true);
 

--- a/app/src/main/java/com/example/gsyvideoplayer/PlayActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/PlayActivity.java
@@ -108,7 +108,7 @@ public class PlayActivity extends AppCompatActivity {
         //videoPlayer.setDialogProgressColor(getResources().getColor(R.color.colorAccent), -11);
 
         //是否可以滑动调整
-        videoPlayer.setIsTouchWiget(true);
+        videoPlayer.setIsTouchWidget(true);
 
         //设置返回按键功能
         videoPlayer.getBackButton().setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/example/gsyvideoplayer/PlayPickActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/PlayPickActivity.java
@@ -90,7 +90,7 @@ public class PlayPickActivity extends AppCompatActivity {
         });
 
         //是否可以滑动调整
-        videoPlayer.setIsTouchWiget(true);
+        videoPlayer.setIsTouchWidget(true);
 
         //设置返回按键功能
         videoPlayer.getBackButton().setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/example/gsyvideoplayer/ScrollingActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/ScrollingActivity.java
@@ -68,7 +68,7 @@ public class ScrollingActivity extends AppCompatActivity {
 
         GSYVideoOptionBuilder gsyVideoOption = new GSYVideoOptionBuilder();
         gsyVideoOption.setThumbImageView(imageView)
-                .setIsTouchWiget(true)
+                .setIsTouchWidget(true)
                 .setRotateViewAuto(false)
                 .setLockLand(false)
                 .setShowFullAnimation(false)

--- a/app/src/main/java/com/example/gsyvideoplayer/WebDetailActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/WebDetailActivity.java
@@ -133,7 +133,7 @@ public class WebDetailActivity extends GSYBaseActivityDetail<StandardGSYVideoPla
                 .setCacheWithPlay(false)
                 .setRotateWithSystem(false)
                 .setVideoTitle("测试视频")
-                .setIsTouchWiget(true)
+                .setIsTouchWidget(true)
                 .setRotateViewAuto(false)
                 .setLockLand(false)
                 .setShowFullAnimation(false)

--- a/app/src/main/java/com/example/gsyvideoplayer/adapter/ListMultiNormalAdapter.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/adapter/ListMultiNormalAdapter.java
@@ -97,7 +97,7 @@ public class ListMultiNormalAdapter extends BaseAdapter {
         holder.gsyVideoPlayer.setLockLand(true);
         holder.gsyVideoPlayer.setReleaseWhenLossAudio(false);
         holder.gsyVideoPlayer.setShowFullAnimation(true);
-        holder.gsyVideoPlayer.setIsTouchWiget(false);
+        holder.gsyVideoPlayer.setIsTouchWidget(false);
 
         holder.gsyVideoPlayer.setNeedLockFull(true);
 

--- a/app/src/main/java/com/example/gsyvideoplayer/adapter/ListNormalAdapter.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/adapter/ListNormalAdapter.java
@@ -154,7 +154,7 @@ public class ListNormalAdapter extends BaseAdapter {
         holder.gsyVideoPlayer.setAutoFullWithSize(true);
         holder.gsyVideoPlayer.setReleaseWhenLossAudio(false);
         holder.gsyVideoPlayer.setShowFullAnimation(!getListNeedAutoLand());
-        holder.gsyVideoPlayer.setIsTouchWiget(false);
+        holder.gsyVideoPlayer.setIsTouchWidget(false);
         //循环
         //holder.gsyVideoPlayer.setLooping(true);
         holder.gsyVideoPlayer.setNeedLockFull(true);

--- a/app/src/main/java/com/example/gsyvideoplayer/exo/DetailExoListPlayer.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/exo/DetailExoListPlayer.java
@@ -60,7 +60,7 @@ public class DetailExoListPlayer extends GSYBaseActivityDetail<GSYExo2PlayerView
 
         resolveNormalVideoUI();
 
-        detailPlayer.setIsTouchWiget(true);
+        detailPlayer.setIsTouchWidget(true);
         //关闭自动旋转
         detailPlayer.setRotateViewAuto(false);
         detailPlayer.setLockLand(false);

--- a/app/src/main/java/com/example/gsyvideoplayer/holder/RecyclerItemNormalHolder.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/holder/RecyclerItemNormalHolder.java
@@ -73,7 +73,7 @@ public class RecyclerItemNormalHolder extends RecyclerItemBaseHolder {
         //防止错位，离开释放
         //gsyVideoPlayer.initUIState();
         gsyVideoOptionBuilder
-                .setIsTouchWiget(false)
+                .setIsTouchWidget(false)
                 .setThumbImageView(imageView)
                 .setUrl(url)
                 .setVideoTitle(title)

--- a/app/src/main/java/com/example/gsyvideoplayer/simple/SimpleDetailActivityMode1.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/simple/SimpleDetailActivityMode1.java
@@ -48,7 +48,7 @@ public class SimpleDetailActivityMode1 extends GSYBaseActivityDetail<StandardGSY
                 .setUrl(url)
                 .setCacheWithPlay(true)
                 .setVideoTitle(" ")
-                .setIsTouchWiget(true)
+                .setIsTouchWidget(true)
                 .setRotateViewAuto(false)
                 .setLockLand(false)
                 .setShowFullAnimation(false)//打开动画

--- a/app/src/main/java/com/example/gsyvideoplayer/simple/SimpleDetailActivityMode2.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/simple/SimpleDetailActivityMode2.java
@@ -52,7 +52,7 @@ public class SimpleDetailActivityMode2 extends AppCompatActivity {
 
         GSYVideoOptionBuilder gsyVideoOption = new GSYVideoOptionBuilder();
         gsyVideoOption.setThumbImageView(imageView)
-                .setIsTouchWiget(true)
+                .setIsTouchWidget(true)
                 .setRotateViewAuto(false)
                 .setLockLand(false)
                 .setAutoFullWithSize(true)

--- a/app/src/main/java/com/example/gsyvideoplayer/simple/SimplePlayer.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/simple/SimplePlayer.java
@@ -50,7 +50,7 @@ public class SimplePlayer extends AppCompatActivity {
             }
         });
         //是否可以滑动调整
-        videoPlayer.setIsTouchWiget(true);
+        videoPlayer.setIsTouchWidget(true);
         //设置返回按键功能
         videoPlayer.getBackButton().setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/com/example/gsyvideoplayer/simple/adapter/SimpleListVideoModeAdapter.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/simple/adapter/SimpleListVideoModeAdapter.java
@@ -100,7 +100,7 @@ public class SimpleListVideoModeAdapter extends BaseAdapter {
         //全屏动画
         holder.gsyVideoPlayer.setShowFullAnimation(true);
         //小屏时不触摸滑动
-        holder.gsyVideoPlayer.setIsTouchWiget(false);
+        holder.gsyVideoPlayer.setIsTouchWidget(false);
         //全屏是否需要lock功能
         return convertView;
 

--- a/app/src/main/java/com/example/gsyvideoplayer/switchplay/SwitchDetailActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/switchplay/SwitchDetailActivity.java
@@ -58,7 +58,7 @@ public class SwitchDetailActivity extends AppCompatActivity {
 
         SwitchUtil.clonePlayState(detailPlayer);
 
-        detailPlayer.setIsTouchWiget(true);
+        detailPlayer.setIsTouchWidget(true);
 
         detailPlayer.setVideoAllCallBack(new GSYSampleCallBack() {
                     @Override

--- a/app/src/main/java/com/example/gsyvideoplayer/switchplay/SwitchUtil.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/switchplay/SwitchUtil.java
@@ -29,7 +29,7 @@ public class SwitchUtil {
         //全屏动画
         gsyVideoPlayer.setShowFullAnimation(false);
         //小屏时不触摸滑动
-        gsyVideoPlayer.setIsTouchWiget(false);
+        gsyVideoPlayer.setIsTouchWidget(false);
 
         gsyVideoPlayer.setSwitchUrl(url);
 

--- a/app/src/main/java/com/example/gsyvideoplayer/utils/SmallVideoHelper.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/utils/SmallVideoHelper.java
@@ -642,12 +642,12 @@ public class SmallVideoHelper {
             return mLooping;
         }
 
-        public boolean isIsTouchWiget() {
-            return mIsTouchWiget;
+        public boolean isIsTouchWidget() {
+            return mIsTouchWidget;
         }
 
-        public boolean isIsTouchWigetFull() {
-            return mIsTouchWigetFull;
+        public boolean isIsTouchWidgetFull() {
+            return mIsTouchWidgetFull;
         }
 
         public boolean isShowPauseCover() {

--- a/app/src/main/java/com/example/gsyvideoplayer/view/FloatPlayerView.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/view/FloatPlayerView.java
@@ -53,7 +53,7 @@ public class FloatPlayerView extends FrameLayout {
         videoPlayer.setThumbImageView(imageView);*/
 
         //是否可以滑动调整
-        videoPlayer.setIsTouchWiget(false);
+        videoPlayer.setIsTouchWidget(false);
 
     }
 

--- a/doc/USE.md
+++ b/doc/USE.md
@@ -51,7 +51,7 @@ holder.gsyVideoPlayer.setReleaseWhenLossAudio(false);
 //全屏动画
 holder.gsyVideoPlayer.setShowFullAnimation(true);
 //小屏时不触摸滑动
-holder.gsyVideoPlayer.setIsTouchWiget(false);
+holder.gsyVideoPlayer.setIsTouchWidget(false);
 ```
 
 3、Activity中配置生命周期
@@ -311,7 +311,7 @@ public class DetailControlActivity extends GSYBaseActivityDetail<StandardGSYVide
                 .setUrl(url)
                 .setCacheWithPlay(true)
                 .setVideoTitle(" ")
-                .setIsTouchWiget(true)
+                .setIsTouchWidget(true)
                 .setRotateViewAuto(false)
                 .setLockLand(false)
                 .setShowFullAnimation(false)
@@ -354,7 +354,7 @@ orientationUtils.setEnable(false);
 
 GSYVideoOptionBuilder gsyVideoOption = new GSYVideoOptionBuilder();
 gsyVideoOption.setThumbImageView(imageView)
-        .setIsTouchWiget(true)
+        .setIsTouchWidget(true)
         .setRotateViewAuto(false)
         .setLockLand(false)
         .setAutoFullWithSize(true)

--- a/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/builder/GSYVideoOptionBuilder.java
+++ b/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/builder/GSYVideoOptionBuilder.java
@@ -75,10 +75,10 @@ public class GSYVideoOptionBuilder {
     protected boolean mLooping = false;
 
     //是否支持非全屏滑动触摸有效
-    protected boolean mIsTouchWiget = true;
+    protected boolean mIsTouchWidget = true;
 
     //是否支持全屏滑动触摸有效
-    protected boolean mIsTouchWigetFull = true;
+    protected boolean mIsTouchWidgetFull = true;
 
     //是否显示暂停图片
     protected boolean mShowPauseCover = true;
@@ -246,8 +246,8 @@ public class GSYVideoOptionBuilder {
      * 是否可以滑动界面改变进度，声音等
      * 默认true
      */
-    public GSYVideoOptionBuilder setIsTouchWiget(boolean isTouchWiget) {
-        this.mIsTouchWiget = isTouchWiget;
+    public GSYVideoOptionBuilder setIsTouchWidget(boolean isTouchWidget) {
+        this.mIsTouchWidget = isTouchWidget;
         return this;
     }
 
@@ -255,8 +255,8 @@ public class GSYVideoOptionBuilder {
      * 是否可以全屏滑动界面改变进度，声音等
      * 默认 true
      */
-    public GSYVideoOptionBuilder setIsTouchWigetFull(boolean isTouchWigetFull) {
-        this.mIsTouchWigetFull = isTouchWigetFull;
+    public GSYVideoOptionBuilder setIsTouchWidgetFull(boolean isTouchWidgetFull) {
+        this.mIsTouchWidgetFull = isTouchWidgetFull;
         return this;
     }
 
@@ -618,8 +618,8 @@ public class GSYVideoOptionBuilder {
         gsyVideoPlayer.setLockLand(mLockLand);
         gsyVideoPlayer.setSpeed(mSpeed, mSounchTouch);
         gsyVideoPlayer.setHideKey(mHideKey);
-        gsyVideoPlayer.setIsTouchWiget(mIsTouchWiget);
-        gsyVideoPlayer.setIsTouchWigetFull(mIsTouchWigetFull);
+        gsyVideoPlayer.setIsTouchWidget(mIsTouchWidget);
+        gsyVideoPlayer.setIsTouchWidgetFull(mIsTouchWidgetFull);
         gsyVideoPlayer.setNeedShowWifiTip(mNeedShowWifiTip);
         gsyVideoPlayer.setEffectFilter(mEffectFilter);
         gsyVideoPlayer.setStartAfterPrepared(mStartAfterPrepared);

--- a/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/utils/GSYVideoHelper.java
+++ b/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/utils/GSYVideoHelper.java
@@ -642,12 +642,12 @@ public class GSYVideoHelper {
             return mLooping;
         }
 
-        public boolean isIsTouchWiget() {
-            return mIsTouchWiget;
+        public boolean isIsTouchWidget() {
+            return mIsTouchWidget;
         }
 
-        public boolean isIsTouchWigetFull() {
-            return mIsTouchWigetFull;
+        public boolean isIsTouchWidgetFull() {
+            return mIsTouchWidgetFull;
         }
 
         public boolean isShowPauseCover() {

--- a/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYBaseVideoPlayer.java
+++ b/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYBaseVideoPlayer.java
@@ -243,7 +243,7 @@ public abstract class GSYBaseVideoPlayer extends GSYVideoControlView {
             to.setUp(from.mOriginUrl, from.mCache, from.mCachePath, from.mMapHeadData, from.mTitle);
         }
         to.setLooping(from.isLooping());
-        to.setIsTouchWigetFull(from.mIsTouchWigetFull);
+        to.setIsTouchWidgetFull(from.mIsTouchWidgetFull);
         to.setSpeed(from.getSpeed(), from.mSoundTouch);
         to.setStateAndUi(from.mCurrentState);
     }
@@ -743,7 +743,7 @@ public abstract class GSYBaseVideoPlayer extends GSYVideoControlView {
 
             cloneParams(this, gsyVideoPlayer);
 
-            gsyVideoPlayer.setIsTouchWiget(false);//小窗口不能点击
+            gsyVideoPlayer.setIsTouchWidget(false);//小窗口不能点击
 
             gsyVideoPlayer.addTextureView();
             //隐藏掉所有的弹出状态哟

--- a/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYVideoControlView.java
+++ b/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYVideoControlView.java
@@ -107,10 +107,10 @@ public abstract class GSYVideoControlView extends GSYVideoView implements View.O
     protected boolean mNeedShowWifiTip = true;
 
     //是否支持非全屏滑动触摸有效
-    protected boolean mIsTouchWiget = true;
+    protected boolean mIsTouchWidget = true;
 
     //是否支持全屏滑动触摸有效
-    protected boolean mIsTouchWigetFull = true;
+    protected boolean mIsTouchWidgetFull = true;
 
     //是否点击封面播放
     protected boolean mThumbPlay;
@@ -470,8 +470,8 @@ public abstract class GSYVideoControlView extends GSYVideoView implements View.O
                     float absDeltaX = Math.abs(deltaX);
                     float absDeltaY = Math.abs(deltaY);
 
-                    if ((mIfCurrentIsFullscreen && mIsTouchWigetFull)
-                            || (mIsTouchWiget && !mIfCurrentIsFullscreen)) {
+                    if ((mIfCurrentIsFullscreen && mIsTouchWidgetFull)
+                            || (mIsTouchWidget && !mIfCurrentIsFullscreen)) {
                         if (!mChangePosition && !mChangeVolume && !mBrightness) {
                             touchSurfaceMoveFullLogic(absDeltaX, absDeltaY);
                         }
@@ -1249,8 +1249,8 @@ public abstract class GSYVideoControlView extends GSYVideoView implements View.O
      * 是否可以全屏滑动界面改变进度，声音等
      * 默认 true
      */
-    public void setIsTouchWigetFull(boolean isTouchWigetFull) {
-        this.mIsTouchWigetFull = isTouchWigetFull;
+    public void setIsTouchWidgetFull(boolean isTouchWidgetFull) {
+        this.mIsTouchWidgetFull = isTouchWidgetFull;
     }
 
     /**
@@ -1277,20 +1277,20 @@ public abstract class GSYVideoControlView extends GSYVideoView implements View.O
     }
 
 
-    public boolean isTouchWiget() {
-        return mIsTouchWiget;
+    public boolean isTouchWidget() {
+        return mIsTouchWidget;
     }
 
     /**
      * 是否可以滑动界面改变进度，声音等
      * 默认true
      */
-    public void setIsTouchWiget(boolean isTouchWiget) {
-        this.mIsTouchWiget = isTouchWiget;
+    public void setIsTouchWidget(boolean isTouchWidget) {
+        this.mIsTouchWidget = isTouchWidget;
     }
 
-    public boolean isTouchWigetFull() {
-        return mIsTouchWigetFull;
+    public boolean isTouchWidgetFull() {
+        return mIsTouchWidgetFull;
     }
 
     /**


### PR DESCRIPTION
- `mIsTouchWiget` 和 `setIsTouchWiget(true)` 应该是不小心拼错单词了，正确的拼写应该是 `mIsTouchWidget` 和 `setIsTouchWidget(true)`
- 本次 PR 主要内容是全局替换 `Wiget` 成 `Widget`， ` doc/UPDATE_VERSION.md` 除外
- 由于 example 项目的依赖是 maven 包，而不是项目本地源码，导致重命名后 example 项目出现找不到 `mIsTouchWidget` 、`setIsTouchWidget(true)` 类似的报错