### PR TITLE
修复当视频方向是竖直时，在开启自动选择竖屏全屏或者横屏全屏时，在刘海屏或者打孔屏中，标题显示被遮盖的问题（目前Oppo R17会出现该问题…

### DIFF
--- a/app/src/main/java/com/example/gsyvideoplayer/simple/SimpleDetailActivityMode1.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/simple/SimpleDetailActivityMode1.java
@@ -17,7 +17,8 @@ public class SimpleDetailActivityMode1 extends GSYBaseActivityDetail<StandardGSY
 
     StandardGSYVideoPlayer detailPlayer;
 
-    private String url = "http://7xjmzj.com1.z0.glb.clouddn.com/20171026175005_JObCxCE2.mp4";
+//    private String url = "http://7xjmzj.com1.z0.glb.clouddn.com/20171026175005_JObCxCE2.mp4";
+    private String url = "http://alvideo.ippzone.com/zyvd/98/90/b753-55fe-11e9-b0d8-00163e0c0248";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -47,8 +48,9 @@ public class SimpleDetailActivityMode1 extends GSYBaseActivityDetail<StandardGSY
                 .setThumbImageView(imageView)
                 .setUrl(url)
                 .setCacheWithPlay(true)
-                .setVideoTitle(" ")
+                .setVideoTitle("这里是一个竖直方向的视频")
                 .setIsTouchWiget(true)
+                .setAutoFullWithSize(true)
                 .setRotateViewAuto(false)
                 .setLockLand(false)
                 .setShowFullAnimation(false)//打开动画

--- a/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYBaseVideoPlayer.java
+++ b/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYBaseVideoPlayer.java
@@ -14,16 +14,15 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 
+import androidx.transition.TransitionManager;
+
 import com.shuyu.gsyvideoplayer.R;
-import com.shuyu.gsyvideoplayer.view.SmallVideoTouch;
 import com.shuyu.gsyvideoplayer.utils.CommonUtil;
 import com.shuyu.gsyvideoplayer.utils.Debuger;
 import com.shuyu.gsyvideoplayer.utils.OrientationUtils;
+import com.shuyu.gsyvideoplayer.view.SmallVideoTouch;
 
 import java.lang.reflect.Constructor;
-
-
-import androidx.transition.TransitionManager;
 
 import static com.shuyu.gsyvideoplayer.utils.CommonUtil.getActionBarHeight;
 import static com.shuyu.gsyvideoplayer.utils.CommonUtil.getStatusBarHeight;
@@ -193,7 +192,7 @@ public abstract class GSYBaseVideoPlayer extends GSYVideoControlView {
      */
     private void saveLocationStatus(Context context, boolean statusBar, boolean actionBar) {
         getLocationOnScreen(mListItemRect);
-        if(context instanceof Activity) {
+        if (context instanceof Activity) {
             int statusBarH = getStatusBarHeight(context);
             int actionBerH = getActionBarHeight((Activity) context);
             boolean isTranslucent = ((WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS & ((Activity) context).getWindow().getAttributes().flags)
@@ -327,7 +326,7 @@ public abstract class GSYBaseVideoPlayer extends GSYVideoControlView {
                 }
             }, 300);
         } else {
-            if (!isVertical && isLockLand && mOrientationUtils != null ) {
+            if (!isVertical && isLockLand && mOrientationUtils != null) {
                 mOrientationUtils.resolveByClick();
             }
             gsyVideoPlayer.setVisibility(VISIBLE);
@@ -342,6 +341,8 @@ public abstract class GSYBaseVideoPlayer extends GSYVideoControlView {
         mIfCurrentIsFullscreen = true;
 
         checkoutState();
+
+        checkAutoFullWithSizeAndAdaptation(gsyVideoPlayer);
     }
 
     /**
@@ -371,7 +372,7 @@ public abstract class GSYBaseVideoPlayer extends GSYVideoControlView {
             showNavKey(mContext, mSystemUiVisibility);
         }
         showSupportActionBar(mContext, mActionBar, mStatusBar);
-        if(getFullscreenButton() != null) {
+        if (getFullscreenButton() != null) {
             getFullscreenButton().setImageResource(getEnlargeImageRes());
         }
     }
@@ -382,7 +383,7 @@ public abstract class GSYBaseVideoPlayer extends GSYVideoControlView {
      */
     @SuppressWarnings("ResourceType")
     protected void clearFullscreenLayout() {
-        if(!mFullAnimEnd) {
+        if (!mFullAnimEnd) {
             return;
         }
         mIfCurrentIsFullscreen = false;
@@ -518,8 +519,11 @@ public abstract class GSYBaseVideoPlayer extends GSYVideoControlView {
             boolean isV = isVerticalFullByVideoSize();
             Debuger.printfLog("GSYVideoBase onPrepared isVerticalFullByVideoSize " + isV);
             if (isV) {
-                if (mOrientationUtils != null)
+                if (mOrientationUtils != null) {
                     mOrientationUtils.backToProtVideo();
+                    //处理在未开始播放的时候点击全屏
+                    checkAutoFullWithSizeAndAdaptation(this);
+                }
             }
         }
     }
@@ -946,5 +950,46 @@ public abstract class GSYBaseVideoPlayer extends GSYVideoControlView {
      */
     public void setAutoFullWithSize(boolean autoFullWithSize) {
         this.mAutoFullWithSize = autoFullWithSize;
+    }
+
+    /**
+     * 检测是否根据视频尺寸，自动选择竖屏全屏或者横屏全屏；
+     * 并且适配在竖屏横屏时，由于刘海屏或者打孔屏占据空间，导致标题显示被遮盖的问题
+     *
+     * @param gsyVideoPlayer 将要显示的播放器对象
+     */
+    protected void checkAutoFullWithSizeAndAdaptation(final GSYBaseVideoPlayer gsyVideoPlayer) {
+        if (gsyVideoPlayer != null) {
+            //判断是否自动选择；判断是否是竖直的视频；判断是否隐藏状态栏
+            if (isAutoFullWithSize() && isVerticalVideo() && isFullHideStatusBar()) {
+                gsyVideoPlayer.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        gsyVideoPlayer.autoAdaptation();
+                    }
+                }, 100);
+            }
+        }
+    }
+
+    /**
+     * 自动适配在竖屏全屏时，由于刘海屏或者打孔屏占据空间带来的影响(某些机型在全屏时会自动将布局下移（或者添加padding），例如三星S10、小米8；但是也有一些机型在全屏时不会处理，此时，就为了兼容这部分机型)
+     */
+    protected void autoAdaptation() {
+        Context context = getContext();
+        if (isVerticalVideo()) {
+
+            int[] location = new int[2];
+            getLocationOnScreen(location);
+
+            /*同时判断系统是否有自动将布局从statusbar下方开始显示，根据在屏幕中的位置判断*/
+            //如果系统没有将布局下移，那么此时处理
+            if (location[1] == 0) {
+                setPadding(0, CommonUtil.getStatusBarHeight(context), 0, 0);
+                Debuger.printfLog("竖屏，系统未将布局下移");
+            } else {
+                Debuger.printfLog("竖屏，系统将布局下移；y:" + location[1]);
+            }
+        }
     }
 }


### PR DESCRIPTION
修复当视频方向是竖直时，在开启自动选择竖屏全屏或者横屏全屏时，在刘海屏或者打孔屏中，标题显示被遮盖的问题（目前Oppo R17会出现该问题，小米8和三星S10系统已自动处理，不会出现该问题）。

备注：
1.由于格式化代码的原因，导致提交的代码中出现了比源代码多了空格或者移除空行的问题；
2.修改了SimpleDetailActivityMode1中的代码，用于验证该问题。