### PR TITLE
Update one unclear method name

### DIFF
--- a/app/src/main/java/com/example/gsyvideoplayer/AudioDetailPlayer.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/AudioDetailPlayer.java
@@ -208,7 +208,7 @@ public class AudioDetailPlayer extends AppCompatActivity {
         detailPlayer.getBackButton().setVisibility(View.GONE);
     }
 
-    private GSYVideoPlayer getCurPlay() {
+    private GSYVideoPlayer getDetailPlayer() {
         if (detailPlayer.getFullWindowPlayer() != null) {
             return detailPlayer.getFullWindowPlayer();
         }

--- a/app/src/main/java/com/example/gsyvideoplayer/DanmkuVideoActivity.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/DanmkuVideoActivity.java
@@ -218,7 +218,7 @@ public class DanmkuVideoActivity extends AppCompatActivity {
         danmakuVideoPlayer.getBackButton().setVisibility(View.GONE);
     }
 
-    private GSYVideoPlayer getCurPlay() {
+    private GSYVideoPlayer getDanmukuPlayer() {
         if (danmakuVideoPlayer.getFullWindowPlayer() != null) {
             return  danmakuVideoPlayer.getFullWindowPlayer();
         }

--- a/app/src/main/java/com/example/gsyvideoplayer/DetailDownloadPlayer.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/DetailDownloadPlayer.java
@@ -248,7 +248,7 @@ public class DetailDownloadPlayer extends AppCompatActivity {
         detailPlayer.getBackButton().setVisibility(View.GONE);
     }
 
-    private GSYVideoPlayer getCurPlay() {
+    private GSYVideoPlayer getDetailPlayer() {
         if (detailPlayer.getFullWindowPlayer() != null) {
             return detailPlayer.getFullWindowPlayer();
         }

--- a/app/src/main/java/com/example/gsyvideoplayer/DetailListPlayer.java
+++ b/app/src/main/java/com/example/gsyvideoplayer/DetailListPlayer.java
@@ -132,7 +132,7 @@ public class DetailListPlayer extends GSYBaseActivityDetail<ListGSYVideoPlayer> 
         detailPlayer.getBackButton().setVisibility(View.VISIBLE);
     }
 
-    private GSYVideoPlayer getCurPlay() {
+    private GSYVideoPlayer getDetailPlayer() {
         if (detailPlayer.getFullWindowPlayer() != null) {
             return detailPlayer.getFullWindowPlayer();
         }


### PR DESCRIPTION
The original name getCurPlayer is a little bit confusing for people to understand. Because the method returns detailPlayer, I suggestion to fix the method name to getDetailPlayer to make the name of the method makes more sense.