### PR TITLE
fix DataSource error

### DIFF
--- a/gsyVideoPlayer-exo_player2/src/main/java/tv/danmaku/ijk/media/exo2/ExoSourceManager.java
+++ b/gsyVideoPlayer-exo_player2/src/main/java/tv/danmaku/ijk/media/exo2/ExoSourceManager.java
@@ -334,8 +334,10 @@ public class ExoSourceManager {
             if (cache != null) {
                 isCached = resolveCacheState(cache, mDataSource);
                 CacheDataSource.Factory factory = new CacheDataSource.Factory();
-                return factory.
-                        setCache(cache).setCacheReadDataSourceFactory(getDataSourceFactory(context, preview, uerAgent)).setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR);
+                return factory.setCache(cache)
+                        .setCacheReadDataSourceFactory(getDataSourceFactory(context, preview, uerAgent))
+                        .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+                        .setUpstreamDataSourceFactory(getHttpDataSourceFactory(context, preview, uerAgent));
             }
         }
         return getDataSourceFactory(context, preview, uerAgent);
@@ -370,7 +372,8 @@ public class ExoSourceManager {
             dataSourceFactory = sExoMediaSourceInterceptListener.getHttpDataSourceFactory(uerAgent, preview ? null : new DefaultBandwidthMeter.Builder(mAppContext).build(),
                     connectTimeout,
                     readTimeout, mMapHeadData, allowCrossProtocolRedirects);
-        } else {
+        } 
+        if (dataSourceFactory == null) {
             dataSourceFactory = new DefaultHttpDataSource.Factory()
                     .setAllowCrossProtocolRedirects(allowCrossProtocolRedirects)
                     .setConnectTimeoutMs(connectTimeout)


### PR DESCRIPTION
1. CacheDataSource.Factory 未设置 UpstreamDataSourceFactory，导致cache命中失效时走到了默认的dataSource实现，抛异常

2. 当listener返回的dataSourceFactory为空时，没有兜底逻辑，所以将else改为对dataSourceFactory的空判断进行兜底