### PR TITLE
Add proguard rule for StandardGSYVideoPlayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ ExoSourceManager.setExoMediaSourceInterceptListener(new ExoMediaSourceInterceptL
     *** get*();
     void set*(***);
     public <init>(android.content.Context);
+    public <init>(android.content.Context, java.lang.Boolean);
     public <init>(android.content.Context, android.util.AttributeSet);
     public <init>(android.content.Context, android.util.AttributeSet, int);
 }


### PR DESCRIPTION
https://github.com/CarGuo/GSYVideoPlayer/blob/9f6e4e220a1384e62c6af7ca143aa175cbab1cfc/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYBaseVideoPlayer.java#L91-L93

All child views extend `GSYBaseVideoPlayer` which wants to show different layouts was required to override the above constructor. And in most cases, it would be an empty constructor.

https://github.com/CarGuo/GSYVideoPlayer/blob/af3becf7c69e19da602185d00715d266f2b712e0/app/src/main/java/com/example/gsyvideoplayer/video/LandLayoutVideo.java#L25-L30

R8 would remove the useless class constructors. So if you're using AGP 4+, toggle to the Full-screen mode can't find the above constructor which led to using the default constructor.

https://github.com/CarGuo/GSYVideoPlayer/blob/9f6e4e220a1384e62c6af7ca143aa175cbab1cfc/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYBaseVideoPlayer.java#L653-L669


Thus the `mIfCurrentIsFullscreen` would be `false` . And `getLayoutId` can't return a correct layout for land.

https://github.com/CarGuo/GSYVideoPlayer/blob/af3becf7c69e19da602185d00715d266f2b712e0/app/src/main/java/com/example/gsyvideoplayer/video/LandLayoutVideo.java#L72-L78

The easiest way is to add a proguard rule for that constructor. 😃
