### PR TITLE
Adapt Gradle 7.1 for publishing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,6 @@ indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,21 @@ name: CI
 on: [ push, pull_request ]
 
 jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+      - name: Publish artifacts
+        run: ./gradlew publishToMavenLocal
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,9 +7,6 @@ android {
         applicationId "com.example.gsyvideoplayer"
         multiDexEnabled true
 
-        javaCompileOptions {
-            annotationProcessorOptions.includeCompileClasspath = true
-        }
         ndk {
             //设置支持的SO库架构
             abiFilters 'armeabi', 'armeabi-v7a', 'x86'
@@ -40,8 +37,6 @@ android {
     lintOptions {
         abortOnError false
     }
-
-
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,10 @@
 org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -Dfile.encoding=UTF-8
 org.gradle.parallel=true
+
 android.injected.testOnly=false
 android.useAndroidX=true
 android.enableJetifier=true
+
 PROJ_GROUP=com.shuyu
 PROJ_VERSION=8.1.2
 PROJ_WEBSITEURL=https://github.com/CarGuo/GSYVideoPlayer
@@ -10,6 +12,7 @@ PROJ_ISSUETRACKERURL=https://github.com/CarGuo/GSYVideoPlayer/issues
 PROJ_VCSURL=https://github.com/CarGuo/GSYVideoPlayer.git
 PROJ_DESCRIPTION=android video player
 PROJ_USER_MAVEN=GSYVideoPlayer
+
 DEVELOPER_ID=guo
 DEVELOPER_NAME=guoshuyu
 DEVELOPER_EMAIL=359369982@qq.com

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,20 +1,15 @@
 org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -Dfile.encoding=UTF-8
 org.gradle.parallel=true
-
 android.injected.testOnly=false
 android.useAndroidX=true
 android.enableJetifier=true
-
-BINTRAY_USER=carguo
-BINTRAY_KEY=
 PROJ_GROUP=com.shuyu
 PROJ_VERSION=8.1.2
 PROJ_WEBSITEURL=https://github.com/CarGuo/GSYVideoPlayer
-PROJ_ISSUETRACKERURL=
-PROJ_VCSURL=git@github.com:CarGuo/GSYVideoPlayer.git
+PROJ_ISSUETRACKERURL=https://github.com/CarGuo/GSYVideoPlayer/issues
+PROJ_VCSURL=https://github.com/CarGuo/GSYVideoPlayer.git
 PROJ_DESCRIPTION=android video player
 PROJ_USER_MAVEN=GSYVideoPlayer
-
 DEVELOPER_ID=guo
 DEVELOPER_NAME=guoshuyu
 DEVELOPER_EMAIL=359369982@qq.com

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,0 +1,11 @@
+apply plugin: "maven-publish"
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+            }
+        }
+    }
+}

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -5,6 +5,33 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
+
+                group = PROJ_GROUP
+                artifactId = PROJ_ARTIFACTID
+                version = PROJ_VERSION
+
+                pom {
+                    name = PROJ_NAME
+                    description = PROJ_DESCRIPTION
+                    url = PROJ_VCSURL
+                    licenses {
+                        license {
+                            name = "The Apache License, Version 2.0"
+                            url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = DEVELOPER_ID
+                            name = DEVELOPER_NAME
+                        }
+                    }
+                    scm {
+                        connection = PROJ_ISSUETRACKERURL
+                        developerConnection = PROJ_VCSURL
+                        url = PROJ_WEBSITEURL
+                    }
+                }
             }
         }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip

--- a/gsyVideoPlayer-armv5/build.gradle
+++ b/gsyVideoPlayer-armv5/build.gradle
@@ -1,3 +1,4 @@
 apply plugin: 'com.android.library'
 
 apply from: "${rootDir.path}/gradle/base.gradle"
+apply from: "${rootDir.path}/gradle/publish.gradle"

--- a/gsyVideoPlayer-armv64/build.gradle
+++ b/gsyVideoPlayer-armv64/build.gradle
@@ -1,3 +1,4 @@
 apply plugin: 'com.android.library'
 
 apply from: "${rootDir.path}/gradle/base.gradle"
+apply from: "${rootDir.path}/gradle/publish.gradle"

--- a/gsyVideoPlayer-armv7a/build.gradle
+++ b/gsyVideoPlayer-armv7a/build.gradle
@@ -1,3 +1,4 @@
 apply plugin: 'com.android.library'
 
 apply from: "${rootDir.path}/gradle/base.gradle"
+apply from: "${rootDir.path}/gradle/publish.gradle"

--- a/gsyVideoPlayer-exo_player2/build.gradle
+++ b/gsyVideoPlayer-exo_player2/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 apply from: "${rootDir.path}/gradle/base.gradle"
+apply from: "${rootDir.path}/gradle/publish.gradle"
 
 dependencies {
     api viewDependencies.exoPlayer2

--- a/gsyVideoPlayer-java/build.gradle
+++ b/gsyVideoPlayer-java/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 apply from: "${rootDir.path}/gradle/base.gradle"
+apply from: "${rootDir.path}/gradle/publish.gradle"
 
 dependencies {
     implementation androidDependencies.appCompat

--- a/gsyVideoPlayer-x86/build.gradle
+++ b/gsyVideoPlayer-x86/build.gradle
@@ -1,3 +1,4 @@
 apply plugin: 'com.android.library'
 
 apply from: "${rootDir.path}/gradle/base.gradle"
+apply from: "${rootDir.path}/gradle/publish.gradle"

--- a/gsyVideoPlayer-x86_64/build.gradle
+++ b/gsyVideoPlayer-x86_64/build.gradle
@@ -1,3 +1,4 @@
 apply plugin: 'com.android.library'
 
 apply from: "${rootDir.path}/gradle/base.gradle"
+apply from: "${rootDir.path}/gradle/publish.gradle"

--- a/gsyVideoPlayer/build.gradle
+++ b/gsyVideoPlayer/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 apply from: "${rootDir.path}/gradle/base.gradle"
+apply from: "${rootDir.path}/gradle/publish.gradle"
 
 dependencies {
     api project(':gsyVideoPlayer-java')


### PR DESCRIPTION
解决 #3261 升级 Gradle 7.1.1 引发的发布错误：
- 添加 `publish.gradle` 使用 AGP 自带的发布脚本发布，移除 `android-maven-gradle-plugin`，参考 [使用 Maven Publish 插件](https://developer.android.com/studio/build/maven-publish-plugin)
- 需要发布 aar 的模块引用 `publish.gradle`