### PR TITLE
Fixed JDK version support and an OpenJDK distro to support it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,25 +6,31 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11, 11.0.3 ]
     steps:
       - uses: actions/checkout@v2
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: ${{ matrix.java }}
       - name: Publish artifacts
         run: ./gradlew publishToMavenLocal
 
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11, 11.0.3 ]
     steps:
       - uses: actions/checkout@v2
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: ${{ matrix.java }}
       - name: Build
         run: ./gradlew --parallel app:assembleRelease

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: Publish artifacts
         run: ./gradlew publishToMavenLocal
@@ -30,7 +30,7 @@ jobs:
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: Build
         run: ./gradlew --parallel app:assembleRelease

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Publish artifacts
         run: ./gradlew publishToMavenLocal
@@ -30,7 +30,7 @@ jobs:
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Build
         run: ./gradlew --parallel app:assembleRelease


### PR DESCRIPTION
When you do your CI/CD runs via GitHub Actions setup/java, if you use a fixed version, e.g., 11.0.3, as well as the most recent version, e.g., 11, you'll be able to see when a build fails what the reason might be -- if 11.0.3 is green and 11 red, you'll see that the problem is connected to the latest release specifically. Zulu has historical major and minor JDK versions and so support this technique best, for that reason switching to Zulu.