### PR TITLE
修复退出全屏时获取的封面为黑屏的问题

### DIFF
--- a/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYBaseVideoPlayer.java
+++ b/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYBaseVideoPlayer.java
@@ -260,6 +260,7 @@ public abstract class GSYBaseVideoPlayer extends GSYVideoControlView {
         to.mAutoFullWithSize = from.mAutoFullWithSize;
         to.mOverrideExtension = from.mOverrideExtension;
         to.mNeedOrientationUtils = from.mNeedOrientationUtils;
+        to.onAudioFocusChangeListener = from.onAudioFocusChangeListener;
         if (from.mSetUpLazy) {
             to.setUpLazy(from.mOriginUrl, from.mCache, from.mCachePath, from.mMapHeadData, from.mTitle);
             to.mUrl = from.mUrl;

--- a/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYBaseVideoPlayer.java
+++ b/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYBaseVideoPlayer.java
@@ -301,7 +301,7 @@ public abstract class GSYBaseVideoPlayer extends GSYVideoControlView {
             } else if (mShowPauseCover) {
                 //不在了说明已经播放过，还是暂停的话，我们拿回来就好
                 try {
-                    initCover();
+                    gsyVideoPlayer.initCover();
                 } catch (Exception e) {
                     e.printStackTrace();
                     mFullPauseBitmap = null;


### PR DESCRIPTION
initCover()调用的是非全屏播放器截图是黑屏的，gsyVideoPlayer.initCover()是全屏播放器截图