### PR TITLE
修复音频焦点冲突

### DIFF
--- a/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYBaseVideoPlayer.java
+++ b/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/base/GSYBaseVideoPlayer.java
@@ -260,6 +260,7 @@ public abstract class GSYBaseVideoPlayer extends GSYVideoControlView {
         to.mAutoFullWithSize = from.mAutoFullWithSize;
         to.mOverrideExtension = from.mOverrideExtension;
         to.mNeedOrientationUtils = from.mNeedOrientationUtils;
+        to.onAudioFocusChangeListener = from.onAudioFocusChangeListener;
         if (from.mSetUpLazy) {
             to.setUpLazy(from.mOriginUrl, from.mCache, from.mCachePath, from.mMapHeadData, from.mTitle);
             to.mUrl = from.mUrl;


### PR DESCRIPTION
当mReleaseWhenLossAudio为false、全屏播放并暂停的时候
这时要恢复播放调用onVideoResume方法时，会执行mAudioManager.requestAudioFocus方法，又因为onAudioFocusChangeListener未克隆，音频焦点就会被抢占，onAudioFocusChangeListener回调了onLossTransientAudio里的onVideoPause。视频就出现刚恢复播放又被暂停的情况