### PR TITLE
Up ListGSYVideoPlayer轮播场景焦点未移除导致播放器状态错误

### DIFF
--- a/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/ListGSYVideoPlayer.java
+++ b/gsyVideoPlayer-java/src/main/java/com/shuyu/gsyvideoplayer/video/ListGSYVideoPlayer.java
@@ -145,6 +145,7 @@ public class ListGSYVideoPlayer extends StandardGSYVideoPlayer {
     public void onCompletion() {
         releaseNetWorkState();
         if (mPlayPosition < (mUriList.size())) {
+            mAudioManager.abandonAudioFocus(onAudioFocusChangeListener);
             return;
         }
         super.onCompletion();


### PR DESCRIPTION
我这边的业务场景是进入视频页面自动播放，经过排查发现这个判断return调了导致再次进入视频页面不会自动播放，首次是正常的。 onAudioFocusChangeListener注册和移除应该是配对存在的，在这里加上这行代码可以解决我的问题。